### PR TITLE
Fix to work with newest Jai compiler Version, add matchers

### DIFF
--- a/matchers/close_to.jai
+++ b/matchers/close_to.jai
@@ -20,9 +20,9 @@ describe :: (using m: *Close_To_Matcher($T), description: *Description) {
 describe_mismatch :: (using m: *Close_To_Matcher($T), actual: T, description: *Description) {
    append(description, "was ");
    append_value(description, actual);
-   append_value(description, " (delta ");
+   append(description, " (delta ");
    append_value(description, expected - actual);
-   append_value(description, ")");
+   append(description, ")");
 }
 
 #scope_file

--- a/matchers/close_to.jai
+++ b/matchers/close_to.jai
@@ -1,0 +1,35 @@
+close_to :: (expected: $T, $tolerance: float = 0.001) -> *Close_To_Matcher(T) {
+	matcher := TNew(Close_To_Matcher(T));
+   matcher.tolerance = tolerance;
+	matcher.expected = expected;
+	return matcher;
+}
+
+matches :: (using m: *Close_To_Matcher($T), actual: T) -> bool {
+   return Math.abs(expected - actual) <= tolerance;
+}
+
+describe :: (using m: *Close_To_Matcher($T), description: *Description) {
+	info := type_info(T);
+	append(description, "a ");
+	append(description, info.type);
+	append(description, " close to ");
+	append_value(description, expected);
+}
+
+describe_mismatch :: (using m: *Close_To_Matcher($T), actual: T, description: *Description) {
+	append(description, "was ");
+	append_value(description, actual);
+	append_value(description, " (delta ");
+   append_value(description, expected - actual);
+	append_value(description, ")");
+}
+
+#scope_file
+
+Close_To_Matcher :: struct (T: Type) {
+	expected: T;
+   tolerance: float;
+}
+
+Math :: #import "Math";

--- a/matchers/close_to.jai
+++ b/matchers/close_to.jai
@@ -1,8 +1,8 @@
 close_to :: (expected: $T, $tolerance: float = 0.001) -> *Close_To_Matcher(T) {
-	matcher := TNew(Close_To_Matcher(T));
+   matcher := TNew(Close_To_Matcher(T));
    matcher.tolerance = tolerance;
-	matcher.expected = expected;
-	return matcher;
+   matcher.expected = expected;
+   return matcher;
 }
 
 matches :: (using m: *Close_To_Matcher($T), actual: T) -> bool {
@@ -10,25 +10,25 @@ matches :: (using m: *Close_To_Matcher($T), actual: T) -> bool {
 }
 
 describe :: (using m: *Close_To_Matcher($T), description: *Description) {
-	info := type_info(T);
-	append(description, "a ");
-	append(description, info.type);
-	append(description, " close to ");
-	append_value(description, expected);
+   info := type_info(T);
+   append(description, "a ");
+   append(description, info.type);
+   append(description, " close to ");
+   append_value(description, expected);
 }
 
 describe_mismatch :: (using m: *Close_To_Matcher($T), actual: T, description: *Description) {
-	append(description, "was ");
-	append_value(description, actual);
-	append_value(description, " (delta ");
+   append(description, "was ");
+   append_value(description, actual);
+   append_value(description, " (delta ");
    append_value(description, expected - actual);
-	append_value(description, ")");
+   append_value(description, ")");
 }
 
 #scope_file
 
 Close_To_Matcher :: struct (T: Type) {
-	expected: T;
+   expected: T;
    tolerance: float;
 }
 

--- a/matchers/comparison.jai
+++ b/matchers/comparison.jai
@@ -56,7 +56,7 @@ describe_mismatch :: (using m: *Comparison_Matcher($T), actual: T, description: 
 #scope_file
 
 Comparison_Matcher :: struct (T: Type) {
-	compare_to_value: T;
+   compare_to_value: T;
    compare_op : (T, T) -> bool;
    compare_desc : string;
 }

--- a/matchers/comparison.jai
+++ b/matchers/comparison.jai
@@ -1,10 +1,10 @@
 
 build_comparison_matcher :: (compare_to_value : $T, compare_op : $F, compare_desc : string) -> *Comparison_Matcher(T) {
-	matcher := TNew(Comparison_Matcher(T));
+   matcher := TNew(Comparison_Matcher(T));
    matcher.compare_op = compare_op;
-	matcher.compare_to_value = compare_to_value;
+   matcher.compare_to_value = compare_to_value;
    matcher.compare_desc = compare_desc;
-	return matcher;
+   return matcher;
 
 }
 
@@ -41,16 +41,16 @@ matches :: (using m: *Comparison_Matcher($T), actual: T) -> bool {
 }
 
 describe :: (using m: *Comparison_Matcher($T), description: *Description) {
-	info := type_info(T);
-	append(description, "a ");
-	append(description, info.type);
-	append(description, m.compare_desc);
-	append_value(description, compare_to_value);
+   info := type_info(T);
+   append(description, "a ");
+   append(description, info.type);
+   append(description, m.compare_desc);
+   append_value(description, compare_to_value);
 }
 
 describe_mismatch :: (using m: *Comparison_Matcher($T), actual: T, description: *Description) {
-	append(description, "was ");
-	append_value(description, actual);
+   append(description, "was ");
+   append_value(description, actual);
 }
 
 #scope_file

--- a/matchers/comparison.jai
+++ b/matchers/comparison.jai
@@ -1,0 +1,64 @@
+
+build_comparison_matcher :: (compare_to_value : $T, compare_op : $F, compare_desc : string) -> *Comparison_Matcher(T) {
+	matcher := TNew(Comparison_Matcher(T));
+   matcher.compare_op = compare_op;
+	matcher.compare_to_value = compare_to_value;
+   matcher.compare_desc = compare_desc;
+	return matcher;
+
+}
+
+less_than :: (compare_to_value: $T) -> *Comparison_Matcher(T) {
+   compare_op :: (a : T, b : T) -> bool {
+      return a < b;
+   }
+   return build_comparison_matcher(compare_to_value, compare_op, " less than ");
+}
+
+less_than_or_equal_to :: (compare_to_value: $T) -> *Comparison_Matcher(T) {
+   compare_op :: (a : T, b : T) -> bool {
+      return a <= b;
+   }
+   return build_comparison_matcher(compare_to_value, compare_op, " less than or equal to ");
+}
+
+greater_than :: (compare_to_value: $T) -> *Comparison_Matcher(T) {
+   compare_op :: (a : T, b : T) -> bool {
+      return a > b;
+   }
+   return build_comparison_matcher(compare_to_value, compare_op, " greater than ");
+}
+
+greater_than_or_equal_to :: (compare_to_value: $T) -> *Comparison_Matcher(T) {
+   compare_op :: (a : T, b : T) -> bool {
+      return a >= b;
+   }
+   return build_comparison_matcher(compare_to_value, compare_op, " greater than or equal to ");
+}
+
+matches :: (using m: *Comparison_Matcher($T), actual: T) -> bool {
+   return m.compare_op(actual, compare_to_value);
+}
+
+describe :: (using m: *Comparison_Matcher($T), description: *Description) {
+	info := type_info(T);
+	append(description, "a ");
+	append(description, info.type);
+	append(description, m.compare_desc);
+	append_value(description, compare_to_value);
+}
+
+describe_mismatch :: (using m: *Comparison_Matcher($T), actual: T, description: *Description) {
+	append(description, "was ");
+	append_value(description, actual);
+}
+
+#scope_file
+
+Comparison_Matcher :: struct (T: Type) {
+	compare_to_value: T;
+   compare_op : (T, T) -> bool;
+   compare_desc : string;
+}
+
+Math :: #import "Math";

--- a/module.jai
+++ b/module.jai
@@ -82,6 +82,8 @@ output_recorded_log :: () {
 #load "matchers/count.jai";
 #load "matchers/is.jai";
 #load "matchers/not.jai";
+#load "matchers/close_to.jai";
+#load "matchers/comparison.jai";
 
 #scope_module
 

--- a/run.jai
+++ b/run.jai
@@ -1,5 +1,6 @@
 INTERNAL_PREAMBLE :: #string END
 #import "stubborn";
+#import "Basic";
 
 print_temporary_usage :: () {
 	mark := get_temporary_storage_mark();
@@ -119,7 +120,7 @@ build_tests :: (base_options: Build_Options, dir: string, preamble := "", module
 
 						array_add(*tests, test);
 					}
-				case .COMPILATION_PHASE;
+				case .PHASE;
 					mp := cast(*Message_Phase) message;
 					if mp.phase == .TYPECHECKED_ALL_WE_CAN && !tests_injected {
 						tests_injected = true;
@@ -137,7 +138,7 @@ build_tests :: (base_options: Build_Options, dir: string, preamble := "", module
 						last_filename: string;
 						for tests {
 							if compare(last_filename, it.filename) {
-								print_to_builder(*test_builder, "print(\"%%:\\n\", \"%\");\n", it.filename);
+								print_to_builder(*test_builder, "print(\"\%:\\n\", \"%\");\n", it.filename);
 								last_filename = it.filename;
 							}
 							template: string;


### PR DESCRIPTION
Added a few small fixes to make it work with latest Jai compiler version.

Also added matchers for close_to, and various inequality matchers.

Example usage:
```
test_close_to :: (){
   assert_that(3.5, close_to(3.5));
   assert_that(3.5, close_to(3.5001));
   assert_that(3.5, close_to(3.6, 0.1));
   assert_that(3.5, close_to(2.0)); // error
} @Test

test_compare :: (){
   assert_that(3.0, greater_than(2.0));
   assert_that(3.0, greater_than_or_equal_to(3.0));
   assert_that(3.0, greater_than_or_equal_to(2.999));
   assert_that(3.0, less_than(3.01));
   assert_that(3.0, less_than(4.0));
   assert_that(3.0, less_than_or_equal_to(3.0));
   assert_that(3.0, less_than_or_equal_to(3.01));
   assert_that(3.0, greater_than(4.5));  // error
} @Test
```